### PR TITLE
Fix nameko requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.so
 *~
 .eggs/
+.python-version
 
 # due to using tox and pytest
 .tox

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ setup(
     ],
     keywords='sample setuptools development',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=[],
+    install_requires=[
+        'nameko<2.5.0'
+    ],
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage', 'pytest', 'tox'],

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pygments
     pytest
     docutils
-    nameko
+    nameko<2.5.0
     kombu<4.0
 commands =
     check-manifest --ignore tox.ini,tests*,circle.yml,*.txt,*.md


### PR DESCRIPTION
**Fix nameko requirement**
Since we rely on stuff internal to nameko and the internals have changed in
later versions, let the test depend on an older nameko version.